### PR TITLE
Building a MinGW version for Windows rather than relying on Cosmopolitan

### DIFF
--- a/Powfiles/pow_cmds.mjs
+++ b/Powfiles/pow_cmds.mjs
@@ -195,4 +195,30 @@ export class PowUpdate {
   }
 }
 
+export class PowWineShell {
+  helpShort = "Start a docker container with wine and open a shell";
+  run(_ctx, argv) {
+    const cp = pow.spawnSync("docker", ["build", dp, "-t", "pow-wine", "wine/"], {
+      cwd: pow.baseDir,
+      stdio: "inherit",
+    });
+    if (cp.status !== 0) {
+      return cp.status;
+    }
+
+    const dockerArgs = [
+      "run",
+      "--rm",
+      `--volume=${dir}/dist/mingw/:/dist/mingw/`,
+      "-it",
+      "pow-wine",
+    ];
+
+    return pow.spawnSync("docker", dockerArgs, {
+      cwd: pow.baseDir,
+      stdio: "inherit",
+    }).status;
+  }
+}
+
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,26 @@
 FROM debian
 
-RUN apt update && apt install -y build-essential git zip && date=2022-04-23
+RUN true date=2022-07-15
+RUN apt-get update && apt-get install -y build-essential gcc-mingw-w64-x86-64 git zip
 
 WORKDIR /build/
-RUN git clone https://github.com/jart/cosmopolitan && cd cosmopolitan && git reset --hard 0a589add4167c1b5873eddd2904569e90bf4f27c
+
+RUN git clone https://github.com/jart/cosmopolitan.git cosmopolitan \
+    && cd cosmopolitan && git reset --hard 4700984456b17169730414fbba24235cc3aad504
+
+RUN mkdir windows && git clone https://github.com/bellard/quickjs.git windows/quickjs \
+    && cd windows/quickjs && git reset --hard b5e62895c619d4ffc75c9d822c8d85f1ece77e5b
+
 ADD build-qjs /bin/
-RUN build-qjs /build/qjs.com
+RUN build-qjs cosmo /build/qjs.com
+RUN build-qjs win /build/qjs.exe
 
+ADD patch-qjs /bin/
 ADD qjs_pow.c .
-RUN sed 's/^int main(/int orig_main(/' -i cosmopolitan/third_party/quickjs/qjs.c \
-    && cat qjs_pow.c >> cosmopolitan/third_party/quickjs/qjs.c
+RUN patch-qjs qjs_pow.c
 
-RUN build-qjs /build/pow_runner.com
+RUN build-qjs cosmo /build/pow_runner.com
+RUN build-qjs win /build/pow.exe
 
 ADD build-pow /bin/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM debian
 RUN apt update && apt install -y build-essential git zip && date=2022-04-23
 
 WORKDIR /build/
-RUN git clone https://github.com/jart/cosmopolitan && cd cosmopolitan && git reset --hard 9a6bd304a58b89277b8a2d490bfda9fd12d19370
+RUN git clone https://github.com/jart/cosmopolitan && cd cosmopolitan && git reset --hard 0a589add4167c1b5873eddd2904569e90bf4f27c
 ADD build-qjs /bin/
 RUN build-qjs /build/qjs.com
 

--- a/docker/build-pow
+++ b/docker/build-pow
@@ -4,15 +4,17 @@ set -exuo pipefail
 
 tmpdir=$(mktemp -d)
 cd "$tmpdir"
+mkdir mjs
 
-cp /pow/lib.*.mjs .
-cp /pow/pow.*.mjs .
-cp /pow/pow.mjs .
 cp /build/pow_runner.com pow.com
+cp /pow/lib.*.mjs mjs/
+cp /pow/pow.*.mjs mjs/
+cp /pow/pow.mjs mjs/
 
-zip pow.com lib.*.mjs
-zip pow.com pow.*.mjs
-zip pow.com pow.mjs
+(
+  cd mjs/
+  zip ../pow.com *.mjs
+)
 
 mkdir -p /dist/macos
 cp pow.com pow-macos
@@ -27,6 +29,11 @@ mv -b pow-linux /dist/linux/pow
 
 mkdir -p /dist/windows
 mv -b pow.com /dist/windows/pow.exe
+
+mkdir -p /dist/mingw
+cp /build/pow.exe /dist/mingw/pow.exe
+# For MinGW build we need to distribute the JS files as well
+cp mjs/*.mjs /dist/mingw/
 
 if [ -e /dist/gitmodules/pow-dist-darwin/pow ]; then
   cp /dist/macos/pow /dist/gitmodules/pow-dist-darwin/

--- a/docker/build-qjs
+++ b/docker/build-qjs
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+type=""
+file=""
+
+if [ "$#" -ge 2 ]; then
+  type="$1"  # win/cosmo
+  file="$2"
+fi
+
 need_demzify() {
   cp -n /build/cosmopolitan/build/bootstrap/apetest.com /build/apetest.com
   [ "$(/build/apetest.com)" != success ]
@@ -15,7 +23,15 @@ demzify() {
   echo  ====================
   echo
 
-  sed s/MZqFpD/Ue6OCi/g -i $(find_com)
+  for comfile in $(find_com); do
+    # Replace the magic MZ marker from the file
+    # but keep the modification time via touch -r
+
+    cp "$comfile" "$comfile.demz"
+    sed s/MZqFpD/Ue6OCi/g -i "$comfile.demz"
+    touch -r "$comfile" "$comfile.demz"
+    mv "$comfile.demz" "$comfile"
+  done
 }
 
 find_com() {
@@ -34,18 +50,38 @@ make_qjs() {
   make -j6 o//third_party/quickjs/qjs.com
 }
 
-cd /build/cosmopolitan/
+make_qjs_exe() {
+  make -j6 CONFIG_WIN32=y LDEXPORT="-static -s -pthread -lpthread" qjs.exe
+}
 
-if need_demzify; then
-  for i in {1..5}; do
-    demzify $i
-    make_qjs || true
-    if ! has_mz_files; then
-      break
-    fi
-  done
+if [ "$type" = win ]; then
+
+  cd /build/windows/quickjs/
+  make_qjs_exe
+  cp qjs.exe "$file"
+
+elif [ "$type" = cosmo ]; then
+
+  cd /build/cosmopolitan/
+
+  if need_demzify; then
+    for i in {1..5}; do
+      demzify $i
+      make_qjs || true
+      if ! has_mz_files; then
+        break
+      fi
+    done
+  fi
+
+  make_qjs
+  cp o/third_party/quickjs/qjs.com "$file"
+
+else
+
+  echo "Usage:
+    $0 cosmo /target/file.com
+    $0 win /target/file.exe" 1>&2
+  exit 1
+
 fi
-
-make_qjs
-cp o/third_party/quickjs/qjs.com "$1"
-

--- a/docker/build-qjs
+++ b/docker/build-qjs
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 need_demzify() {
-  cp -n /build/cosmopolitan/build/sanitycheck2 /build/sanitycheck2
-  [ 123 -ne $(bash -c '/build/sanitycheck2 ; echo $?') ]
+  cp -n /build/cosmopolitan/build/bootstrap/apetest.com /build/apetest.com
+  [ "$(/build/apetest.com)" != success ]
 }
 
 demzify() {
@@ -15,12 +15,11 @@ demzify() {
   echo  ====================
   echo
 
-  echo 'exit 123' > /build/cosmopolitan/build/sanitycheck2
   sed s/MZqFpD/Ue6OCi/g -i $(find_com)
 }
 
 find_com() {
-  find /build/cosmopolitan/ -name '*.com' -not -name qjs.com
+  find /build/cosmopolitan/ -name '*.com' -not -name qjs.com -not -name apetest.com
 }
 
 has_mz_files() {

--- a/docker/patch-qjs
+++ b/docker/patch-qjs
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+target=/build/windows/quickjs/qjs.c
+
+sed 's/^int main(/int orig_main(/' -i "$target" \
+    && cat "$1" >> "$target"
+
+target=/build/cosmopolitan/third_party/quickjs/qjs.c
+
+sed 's/^int main(/int orig_main(/' -i "$target" \
+    && cat "$1" >> "$target"

--- a/docker/qjs_pow.c
+++ b/docker/qjs_pow.c
@@ -1,8 +1,10 @@
 // This file will be included to qjs.c
 // and the original main function will be renamed to orig_main
 
+#include "libc/calls/struct/stat.h"
 #include "libc/isystem/string.h"
 #include "libc/isystem/unistd.h"
+#include "libc/sysv/consts/s.h"
 
 // A few functions borrowed from busybox (and modified a bit)
 // (This is to find the equivalent of `which pow`)

--- a/docker/qjs_pow.c
+++ b/docker/qjs_pow.c
@@ -1,6 +1,8 @@
 // This file will be included to qjs.c
 // and the original main function will be renamed to orig_main
 
+#if defined(COSMO)
+
 #include "libc/calls/struct/stat.h"
 #include "libc/isystem/string.h"
 #include "libc/isystem/unistd.h"
@@ -52,10 +54,15 @@ int find_executable(const char *filename, char *p, char *buffer)
     return 0;
 }
 
+#endif /* COSMO */
+
 // New main
 
 int main(int argc, char **argv)
 {
+
+#if defined(COSMO)
+
     if (!file_is_executable(argv[0]))
     {
 
@@ -71,9 +78,40 @@ int main(int argc, char **argv)
         }
     }
 
+#endif /* COSMO */
+
     JSRuntime *rt;
     JSContext *ctx;
     int repl = 0;
+
+    char *filename = "/zip/pow.mjs";
+
+#if defined(_WIN32)
+
+    // On MinGW build we put the .mjs files next to pow.exe
+    // as we don't have the mechanism to embed them to the binary
+    //
+    // Example location of pow.exe (argv[0]):
+    // C:/Users/gabrys/AppData/Roaming/npm/node_modules/pow-windows/pow.exe
+    //
+    // Corresponding pow.mjs location:
+    // C:/Users/gabrys/AppData/Roaming/npm/node_modules/pow-windows/pow.mjs
+
+    filename = strdup(argv[0]);
+    int len = strlen(filename);
+    int extstart = len - 4;
+
+    if (extstart > 0 && (0 == strcmp(filename + extstart, ".exe"))) {
+        filename[extstart+1] = 'm';
+        filename[extstart+2] = 'j';
+        filename[extstart+3] = 's';
+    }
+
+    for (int i = 0; i < len; i++)
+        if (filename[i] == '\\')
+            filename[i] = '/';
+
+#endif /* _WIN32 */
 
     for (int optind = 1; optind < argc; optind++)
     {
@@ -103,7 +141,7 @@ int main(int argc, char **argv)
     JS_SetModuleLoaderFunc(rt, NULL, js_module_loader, NULL);
     js_std_add_helpers(ctx, argc, argv);
 
-    const char *filename = "/zip/pow.mjs";
+
     if (eval_file(ctx, filename, JS_EVAL_TYPE_MODULE))
         goto fail;
     js_std_loop(ctx);

--- a/pow/pow.utils.mjs
+++ b/pow/pow.utils.mjs
@@ -96,7 +96,11 @@ export class PowLogger {
 
 export class PowUtils {
   constructor() {
-    if (windows) {
+    if (os.platform === "win32") {
+      this.cwd = os.getcwd()[0].replace(/\\/g, "/");
+      this.platform = "win32";
+      this.windows = true;
+    } else if (windows) {
       this.cwd = windowsCwd;
       this.platform = "win32";
       this.windows = true;

--- a/wine/Dockerfile
+++ b/wine/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian
+
+RUN dpkg --add-architecture i386  && apt update && apt install -y wine32 wine64 && date=2022-07-15
+RUN wineboot --init


### PR DESCRIPTION
Seams like QuickJS works a bit better when compiled as a Windows binary (vs APE), plus it doesn't seem to trigger anti-virus software. Still to be found whether it trps the Microsoft's embedded AV or not.

This is not usable though, because Windows's version of QuickJS lacks `os.exec`